### PR TITLE
add: script to bootstrap a devel server

### DIFF
--- a/devel.sh
+++ b/devel.sh
@@ -8,8 +8,8 @@ This script is intended to be used to bootstrap a moth development server. It
 looks like you're running the script from a moth repository working directory.
 
     $ mkdir /tmp/moth
-	$ cd /tmp/moth
-	$ curl https://raw.githubusercontent.com/dirtbags/moth/master/devel.sh | bash
+    $ cd /tmp/moth
+    $ curl https://raw.githubusercontent.com/dirtbags/moth/master/devel.sh | bash
 EOM
 	exit 1
 fi

--- a/devel.sh
+++ b/devel.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+#
+# Script to clone and start a development server
+
+if [[ -f tools/devel-server.py ]]; then
+	cat <<EOM
+This script is intended to be used to bootstrap a moth development server. It
+looks like you're running the script from a moth repository working directory.
+
+    $ mkdir /tmp/moth
+	$ cd /tmp/moth
+	$ curl https://raw.githubusercontent.com/dirtbags/moth/master/devel.sh | bash
+EOM
+	exit 1
+fi
+
+[[ -d puzzles  ]] || mkdir -p puzzles
+[[ -d moth/bin ]] || git clone https://github.com/dirtbags/moth.git
+
+cd moth
+puzzles="$(readlink -e ../puzzles)"
+ln -sf "${puzzles}" puzzles
+
+printf "\n[+] Place puzzles at ${puzzles} ...\n"
+python3 tools/devel-server.py

--- a/devel.sh
+++ b/devel.sh
@@ -11,7 +11,7 @@ looks like you're running the script from a moth repository working directory.
 
     $ mkdir /tmp/moth
     $ cd /tmp/moth
-    $ curl https://raw.githubusercontent.com/dirtbags/moth/master/devel.sh | bash
+    $ curl https://raw.githubusercontent.com/dirtbags/moth/master/devel.sh | sh
 EOM
 	exit 1
 fi

--- a/devel.sh
+++ b/devel.sh
@@ -1,8 +1,10 @@
-#!/bin/bash -e
+#!/bin/sh
 #
 # Script to clone and start a development server
 
-if [[ -f tools/devel-server.py ]]; then
+set -e
+
+if [ -f tools/devel-server.py ]; then
 	cat <<EOM
 This script is intended to be used to bootstrap a moth development server. It
 looks like you're running the script from a moth repository working directory.
@@ -14,8 +16,8 @@ EOM
 	exit 1
 fi
 
-[[ -d puzzles  ]] || mkdir -p puzzles
-[[ -d moth/bin ]] || git clone https://github.com/dirtbags/moth.git
+[ -d puzzles  ] || mkdir -p puzzles
+[ -d moth/bin ] || git clone https://github.com/dirtbags/moth.git
 
 cd moth
 puzzles="$(readlink -e ../puzzles)"


### PR DESCRIPTION
A idempotent script to bootstrap development server. This script, when run in an empty-ish directory will clone moth into ./moth and create a directory at ./puzzles. The puzzle directory is communicated with the user and the development server starts on port 8080.