### PR TITLE
Append current time to request to force reload puzzles.json

### DIFF
--- a/www/res/puzzles.js
+++ b/www/res/puzzles.js
@@ -56,7 +56,7 @@ function puzzles_start() {
   var refreshInterval = 40 * 1000;
 
   var refreshCallback = puzzlesRefresh.bind(undefined, puzzlesTerminal);
-  var refreshFunction = loadJSON.bind(undefined, puzzlesJsonUrl, refreshCallback);
+  var refreshFunction = loadJSON.bind(undefined, puzzlesJsonUrl + '?_=' + new Date().getTime(), refreshCallback);
 
   puzzlesTerminal.clear();
   puzzlesTerminal.par("Loading...");


### PR DESCRIPTION
This is the server-agnostic approach to force reload a resource.
https://stackoverflow.com/questions/22356025/force-cache-control-no-cache-in-chrome-via-xmlhttprequest-on-f5-reload