### PR TITLE
Added www user to list of httpd users

### DIFF
--- a/bin/httpd
+++ b/bin/httpd
@@ -3,7 +3,7 @@
 # Starts a standalone server using tcpsvd and eris
 
 echo "Figuring out web user..."
-for www in www-data http tc _ _www; do
+for www in www www-data http tc _ _www; do
     id $www && break
 done
 if [ $www = _ ]; then


### PR DESCRIPTION
The [eris Dockerfile](https://github.com/nealey/eris/blob/master/Dockerfile) uses `www` as its user so figured it deserved to be in the list.