### PR TITLE
Add local python library support

### DIFF
--- a/devel/devel-server.py
+++ b/devel/devel-server.py
@@ -210,7 +210,6 @@ sessionStorage.setItem("id", "devel-server")
         self.end_headers()
         self.wfile.write(body.encode('utf-8'))
     endpoints.append((r"/", handle_index))
-    #endpoints.append((r"/{ignored}", handle_index))
 
 
     def handle_theme_file(self):

--- a/devel/devel-server.py
+++ b/devel/devel-server.py
@@ -210,7 +210,7 @@ sessionStorage.setItem("id", "devel-server")
         self.end_headers()
         self.wfile.write(body.encode('utf-8'))
     endpoints.append((r"/", handle_index))
-    endpoints.append((r"/{ignored}", handle_index))
+    #endpoints.append((r"/{ignored}", handle_index))
 
 
     def handle_theme_file(self):

--- a/devel/moth.py
+++ b/devel/moth.py
@@ -289,7 +289,7 @@ class Puzzle:
 
         files = [fn for fn,f in self.files.items() if f.visible]
         return {
-            'authors': self.authors,
+            'authors': self.get_authors(),
             'hashes': self.hashes(),
             'files': files,
             'scripts': self.scripts,

--- a/devel/moth.py
+++ b/devel/moth.py
@@ -28,11 +28,12 @@ def djb2hash(str):
 def pushd(newdir):
     curdir = os.getcwd()
     os.chdir(newdir)
+
     # Force a copy of the old path, instead of just a reference
     old_path = list(sys.path)
     old_modules = copy.copy(sys.modules)
     sys.path.append(newdir)
-    print("New path: %s" % (sys.path,))
+
     try:
         yield
     finally:

--- a/example-puzzles/example/200/puzzle.py
+++ b/example-puzzles/example/200/puzzle.py
@@ -1,0 +1,19 @@
+import io
+import categorylib  # Category-level libraries can be imported here
+
+def make(puzzle):
+    import puzzlelib  # puzzle-level libraries can only be imported inside of the make function
+    puzzle.authors = ['donaldson']
+    puzzle.summary = 'more crazy stuff you can do with puzzle generation using Python libraries'
+
+    puzzle.body.write("## Crazy Things You Can Do With Puzzle Generation (part II)\n")
+    puzzle.body.write("\n")
+    puzzle.body.write("The source to this puzzle has some more advanced examples of stuff you can do in Python.\n")
+    puzzle.body.write("\n")
+    puzzle.body.write("1 == %s\n\n" % puzzlelib.getone(),)
+    puzzle.body.write("2 == %s\n\n" % categorylib.gettwo(),)
+
+    puzzle.answers.append('tea')
+    answer = puzzle.make_answer()        # Generates a random answer, appending it to puzzle.answers too
+    puzzle.log("Answers: {}".format(puzzle.answers))
+

--- a/example-puzzles/example/200/puzzlelib.py
+++ b/example-puzzles/example/200/puzzlelib.py
@@ -1,0 +1,7 @@
+"""This is an example of a puzzle-level library.
+
+This library can be imported by child puzzles using `import puzzlelib`
+"""
+
+def getone():
+    return 1

--- a/example-puzzles/example/200/puzzlelib.py
+++ b/example-puzzles/example/200/puzzlelib.py
@@ -1,6 +1,6 @@
 """This is an example of a puzzle-level library.
 
-This library can be imported by child puzzles using `import puzzlelib`
+This library can be imported by sibling puzzles using `import puzzlelib`
 """
 
 def getone():

--- a/example-puzzles/example/categorylib.py
+++ b/example-puzzles/example/categorylib.py
@@ -1,0 +1,7 @@
+"""This is an example of a category-level library.
+
+This library can be imported by child puzzles using `import categorylib`
+"""
+
+def gettwo():
+    return 2


### PR DESCRIPTION
Closes #79 

This may introduce unexpected behaviors if a puzzle imports libraries with a name that collides with a library used in another puzzle or at another level. However, efforts have been taken to reduce the likelihood of colliding libraries, and, if a nefarious individual wanted to nefariously manipulate loaded Python libraries, that could already be accomplished.