### PR TITLE
Add basic metadata to compiled mothballs and devel server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - URL parameter to points.json to allow returning only the JSON for a single
   team by its team id (e.g., points.json?id=abc123).
+- Include basic metadata in mothballs
 
 ## [3.4.3] - 2019-11-20
 ### Fixed

--- a/Dockerfile.moth-devel
+++ b/Dockerfile.moth-devel
@@ -16,6 +16,7 @@ RUN apk --no-cache add \
 COPY devel /app/
 COPY example-puzzles /puzzles/
 COPY theme /theme/
+COPY VERSION /VERSION
 
 ENTRYPOINT [ "python3", "/app/devel-server.py" ]
 CMD [ "--bind", "0.0.0.0:8080", "--puzzles", "/puzzles", "--theme", "/theme" ]

--- a/devel/devel-server.py
+++ b/devel/devel-server.py
@@ -118,6 +118,7 @@ class MothRequestHandler(http.server.SimpleHTTPRequestHandler):
         obj["hint"] = puzzle.hint
         obj["summary"] = puzzle.summary
         obj["logs"] = puzzle.logs
+        obj["format"] = puzzle._source_format
 
         self.send_response(200)
         self.send_header("Content-Type", "application/json")

--- a/devel/moth.py
+++ b/devel/moth.py
@@ -123,6 +123,8 @@ class Puzzle:
 
         super().__init__()
 
+        self._source_format = "py"
+
         self.points = points
         self.summary = None
         self.authors = []
@@ -153,8 +155,10 @@ class Puzzle:
         line = ""
         if stream.read(3) == "---":
             header = "yaml"
+            self._source_format = "yaml"
         else:
             header = "moth"
+            self._source_format = "moth"
 
         stream.seek(0)
 


### PR DESCRIPTION
Adding basic build information to mothballs

Example:
```json
{"platform": {"arch": "armv7l", "os": "Linux", "version": "Linux-4.19.66-v7+-armv7l-with", "python_version": "3.7.2"}, "moth": {"version": "3.4.3"}, "category": {"build_time": "Wed Jan 29 23:48:29 2020", "type": "catmod"}}
```
