### PR TITLE
Remove mutex on sort operation

### DIFF
--- a/src/award.go
+++ b/src/award.go
@@ -14,6 +14,24 @@ type Award struct {
 	Points   int
 }
 
+type AwardList []*Award
+
+// Implement sort.Interface on AwardList
+func (awards AwardList) Len() int {
+  return len(awards)
+}
+
+func (awards AwardList) Less(i, j int) bool {
+  return awards[i].When.Before(awards[j].When)
+}
+
+func (awards AwardList) Swap(i, j int) {
+  tmp := awards[i]
+  awards[i] = awards[j]
+  awards[j] = tmp
+}
+
+
 func ParseAward(s string) (*Award, error) {
 	ret := Award{}
 

--- a/src/award_test.go
+++ b/src/award_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"testing"
+	"sort"
 )
 
 func TestAward(t *testing.T) {
@@ -31,4 +32,24 @@ func TestAward(t *testing.T) {
 	if _, err := ParseAward("1 bad bad bad"); err == nil {
 		t.Error("Not throwing error on bad points")
 	}
+}
+
+func TestAwardList(t *testing.T) {
+  a, _ := ParseAward("1536958399 1a2b3c4d counting 1")
+  b, _ := ParseAward("1536958400 1a2b3c4d counting 1")
+  c, _ := ParseAward("1536958300 1a2b3c4d counting 1")
+  list := AwardList{a, b, c}
+  
+  if sort.IsSorted(list) {
+    t.Error("Unsorted list thinks it's sorted")
+  }
+  
+  sort.Stable(list)
+  if (list[0] != c) || (list[1] != a) || (list[2] != b) {
+    t.Error("Sorting didn't")
+  }
+  
+  if ! sort.IsSorted(list) {
+    t.Error("Sorted list thinks it isn't")
+  }
 }

--- a/src/instance.go
+++ b/src/instance.go
@@ -37,7 +37,6 @@ type Instance struct {
 	nextAttempt       map[string]time.Time
 	nextAttemptMutex  *sync.RWMutex
 	mux               *http.ServeMux
-	PointsMux         *sync.RWMutex
 }
 
 func (ctx *Instance) Initialize() error {
@@ -55,7 +54,6 @@ func (ctx *Instance) Initialize() error {
 	ctx.nextAttempt = map[string]time.Time{}
 	ctx.nextAttemptMutex = new(sync.RWMutex)
 	ctx.mux = http.NewServeMux()
-	ctx.PointsMux = new(sync.RWMutex)
 
 	ctx.BindHandlers()
 	ctx.MaybeInitialize()
@@ -85,10 +83,7 @@ func (ctx *Instance) MaybeInitialize() {
 	// Remove any extant control and state files
 	os.Remove(ctx.StatePath("until"))
 	os.Remove(ctx.StatePath("disabled"))
-
-	ctx.PointsMux.Lock()
 	os.Remove(ctx.StatePath("points.log"))
-	ctx.PointsMux.Unlock()
 
 	os.RemoveAll(ctx.StatePath("points.tmp"))
 	os.RemoveAll(ctx.StatePath("points.new"))
@@ -158,18 +153,15 @@ func (ctx *Instance) TooFast(teamId string) bool {
 	return now.Before(next)
 }
 
-func (ctx *Instance) PointsLog(teamId string) []*Award {
-	var ret []*Award
-
+func (ctx *Instance) PointsLog(teamId string) AwardList {
+	awardlist := AwardList{}
+	
 	fn := ctx.StatePath("points.log")
-
-	ctx.PointsMux.RLock()
-	defer ctx.PointsMux.RUnlock()
 
 	f, err := os.Open(fn)
 	if err != nil {
 		log.Printf("Unable to open %s: %s", fn, err)
-		return ret
+		return awardlist
 	}
 	defer f.Close()
 
@@ -184,10 +176,10 @@ func (ctx *Instance) PointsLog(teamId string) []*Award {
 		if len(teamId) > 0 && cur.TeamId != teamId {
 			continue
 		}
-		ret = append(ret, cur)
+		awardlist = append(awardlist, cur)
 	}
 
-	return ret
+	return awardlist
 }
 
 // AwardPoints gives points to teamId in category.


### PR DESCRIPTION
I didn't look into why the mutex was causing some sort of deadlock condition
on retrieving points. This fixes it, as long as the underlying filesystem
supports atomic file renames. So don't run this with NFS.

Fixes #107. I even tested it a little bit.